### PR TITLE
Cart Action Support

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,6 +43,8 @@ var formatItemParams = function(items) {
     item.CartItemId && !item.Quantity && (itemQtyKey = ["Item", idx, "Quantity"].join("."));
     item.Quantity && (itemQtyKey = ["Item", idx, "Quantity"].join("."));
     itemIdKey && itemQtyKey && (params[itemIdKey] = itemId, params[itemQtyKey] = item.Quantity);
+    item.Action && 
+      (params[["Item", idx, "Action"].join(".")] = item.Action);
   });
   return params;
 };


### PR DESCRIPTION
Adding support for ‘Action’ item parameter, which, when coupled with CartItemId, allows items to be moved between the remote cart’s main section and the Saved For Later section.